### PR TITLE
MAGECLOUD-3938: Remove magento/* packages from require section for magento-cloud-components.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
   "version": "1.0.0",
   "require": {
     "php": "^7.0",
-    "ext-json": "*",
+    "ext-json": "*"
+  },
+  "suggest": {
     "magento/framework": "*",
     "magento/module-store": "*",
     "magento/module-url-rewrite": "*"


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-3938