### PR TITLE
Enahcne PHPUnit fixture

### DIFF
--- a/Test/Unit/Model/UrlFixerTest.php
+++ b/Test/Unit/Model/UrlFixerTest.php
@@ -21,7 +21,7 @@ class UrlFixerTest extends TestCase
      * @var UrlFixer
      */
     private $urlFixer;
-    
+
     /**
      * @var MockObject|Store
      */
@@ -30,7 +30,7 @@ class UrlFixerTest extends TestCase
     /**
      * @inheritDoc
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->storeMock = $this->createPartialMock(Store::class, ['getForceDisableRewrites', 'getConfig']);
         $this->urlFixer = new UrlFixer();


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/6.5/en/fixtures.html), the `setUp` method should be `protected`, not `public`.