### PR TITLE
MCLOUD-6023: Investigate Redis scan keys eviction

### DIFF
--- a/Console/Command/CacheEvict.php
+++ b/Console/Command/CacheEvict.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudComponents\Console\Command;
+
+use Magento\CloudComponents\Model\Cache\Evictor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Performs force key eviction with a "scan" command.
+ */
+class CacheEvict extends Command
+{
+    /**
+     * @var Evictor
+     */
+    private $evictor;
+
+    /**
+     * @param Evictor $evictor
+     */
+    public function __construct(Evictor $evictor)
+    {
+        $this->evictor = $evictor;
+
+        parent::__construct('cache:evict');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure()
+    {
+        $this->setDescription('Evicts unused keys');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Begin key eviction');
+
+        $count = $this->evictor->evict();
+
+        $output->writeln(sprintf(
+            'Total evicted keys: %s',
+            $count
+        ));
+    }
+}

--- a/Console/Command/CacheEvict.php
+++ b/Console/Command/CacheEvict.php
@@ -37,7 +37,7 @@ class CacheEvict extends Command
      */
     protected function configure()
     {
-        $this->setDescription('Evicts unused keys');
+        $this->setDescription('Evicts unused keys by performing scan command');
     }
 
     /**
@@ -45,12 +45,12 @@ class CacheEvict extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Begin eviction of cache keys');
+        $output->writeln('Begin scanning of cache keys');
 
         $count = $this->evictor->evict();
 
         $output->writeln(sprintf(
-            'Total evicted keys: %s',
+            'Total scanned keys: %s',
             $count
         ));
     }

--- a/Console/Command/CacheEvict.php
+++ b/Console/Command/CacheEvict.php
@@ -45,7 +45,7 @@ class CacheEvict extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Begin key eviction');
+        $output->writeln('Begin eviction of cache keys');
 
         $count = $this->evictor->evict();
 

--- a/Cron/Evict.php
+++ b/Cron/Evict.php
@@ -48,7 +48,7 @@ class Evict
      */
     public function execute()
     {
-        if (!$this->deploymentConfig->get(Evictor::CONFIG_PATH)) {
+        if (!$this->deploymentConfig->get(Evictor::CONFIG_PATH_ENABLED)) {
             $this->logger->info('Keys eviction is disabled');
 
             return;

--- a/Cron/Evict.php
+++ b/Cron/Evict.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudComponents\Cron;
+
+use Magento\CloudComponents\Model\Cache\Evictor;
+
+class Eviction
+{
+    /**
+     * @var Evictor
+     */
+    private $evictor;
+
+    /**
+     * @param Evictor $evictor
+     */
+    public function __construct(Evictor $evictor)
+    {
+        $this->evictor = $evictor;
+    }
+
+    /**
+     * Perform keys eviction.
+     */
+    public function execute()
+    {
+        $this->evictor->evict();
+    }
+}

--- a/Cron/Evict.php
+++ b/Cron/Evict.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace Magento\CloudComponents\Cron;
 
 use Magento\CloudComponents\Model\Cache\Evictor;
+use Magento\Framework\App\DeploymentConfig;
+use Psr\Log\LoggerInterface;
 
 class Eviction
 {
@@ -17,11 +19,25 @@ class Eviction
     private $evictor;
 
     /**
-     * @param Evictor $evictor
+     * @var DeploymentConfig
      */
-    public function __construct(Evictor $evictor)
+    private $deploymentConfig;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param Evictor $evictor
+     * @param DeploymentConfig $deploymentConfig
+     * @param LoggerInterface $logger
+     */
+    public function __construct(Evictor $evictor, DeploymentConfig $deploymentConfig, LoggerInterface $logger)
     {
         $this->evictor = $evictor;
+        $this->deploymentConfig = $deploymentConfig;
+        $this->logger = $logger;
     }
 
     /**
@@ -29,6 +45,12 @@ class Eviction
      */
     public function execute()
     {
+        if (!$this->deploymentConfig->get(Evictor::CONFIG_PATH)) {
+            $this->logger->debug('Keys eviction is disabled');
+
+            return;
+        }
+
         $this->evictor->evict();
     }
 }

--- a/Cron/Evict.php
+++ b/Cron/Evict.php
@@ -46,7 +46,7 @@ class Eviction
     public function execute()
     {
         if (!$this->deploymentConfig->get(Evictor::CONFIG_PATH)) {
-            $this->logger->debug('Keys eviction is disabled');
+            $this->logger->info('Keys eviction is disabled');
 
             return;
         }

--- a/Cron/Evict.php
+++ b/Cron/Evict.php
@@ -11,7 +11,10 @@ use Magento\CloudComponents\Model\Cache\Evictor;
 use Magento\Framework\App\DeploymentConfig;
 use Psr\Log\LoggerInterface;
 
-class Eviction
+/**
+ * The cron cprocess to evict keys.
+ */
+class Evict
 {
     /**
      * @var Evictor

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -63,7 +63,7 @@ class Evictor
                 $cacheConfig['backend_options']['database']
             )) {
                 $this->logger->debug(sprintf(
-                    'Cache for database "%s" config is not valid',
+                    'Cache config for database "%s" config is not valid',
                     $name
                 ));
 

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -52,17 +52,18 @@ class Evictor
 
         foreach ($cacheOptions as $name => $cacheConfig) {
             $this->logger->info(sprintf(
-                'Evicting keys for %s database',
+                'Evicting keys for "%s" database',
                 $name
             ));
 
-            $evictedKeys += $this->run(
+            $dbKeys = $this->run(
                 $cacheConfig['backend_options']['server'],
                 $cacheConfig['backend_options']['port'],
                 $cacheConfig['backend_options']['database']
             );
+            $evictedKeys += $dbKeys;
 
-            $this->logger->info('Keys evicted');
+            $this->logger->info(sprintf('Keys evicted: %s', $dbKeys));
         }
 
         return $evictedKeys;
@@ -87,8 +88,6 @@ class Evictor
             } else {
                 $keysCount = count($keys);
                 $evictedKeys += $keysCount;
-
-                $this->logger->debug(sprintf('Evicted keys count: %s', $keysCount));
             }
         } while ($iterator > 0);
 

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -19,6 +19,7 @@ use Cm_Cache_Backend_Redis as Backend;
 class Evictor
 {
     const DEFAULT_EVICTION_LIMIT = 10000;
+    const DEFAULT_SLEEP_TIMEOUT = 100;
     const CONFIG_PATH_ENABLED = 'cache_evict/enabled';
     const CONFIG_PATH_LIMIT = 'cache_evict/limit';
 
@@ -111,7 +112,7 @@ class Evictor
             }
 
             /* Give Redis some time to handle other requests */
-            usleep(100);
+            usleep(self::DEFAULT_SLEEP_TIMEOUT);
         } while ($iterator > 0);
 
         return $evictedKeys;

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -98,7 +98,8 @@ class Evictor
 
         do {
             $keys = $client->scan(
-                $iterator, Backend::PREFIX_KEY . '*',
+                $iterator,
+                Backend::PREFIX_KEY . '*',
                 (int)$this->deploymentConfig->get(self::CONFIG_PATH_LIMIT, self::DEFAULT_EVICTION_LIMIT)
             );
 

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudComponents\Model\Cache;
+
+use Magento\Framework\App\Cache\Type\FrontendPool;
+use Magento\Framework\App\DeploymentConfig;
+use Psr\Log\LoggerInterface;
+use Credis_Client as Client;
+
+/**
+ * Performs force key eviction with a "scan" command.
+ */
+class Evictor
+{
+    const EVICTION_LIMIT = 10000;
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     * @param LoggerInterface $logger
+     */
+    public function __construct(DeploymentConfig $deploymentConfig, LoggerInterface $logger)
+    {
+        $this->deploymentConfig = $deploymentConfig;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Evicts all keys using iterator.
+     *
+     * @return int
+     */
+    public function evict(): int
+    {
+        $cacheOptions = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE)[FrontendPool::KEY_FRONTEND_CACHE] ?? [];
+        $evictedKeys = 0;
+
+        foreach ($cacheOptions as $name => $cacheConfig) {
+            $this->logger->info(sprintf(
+                'Evicting keys for %s database',
+                $name
+            ));
+
+            $evictedKeys += $this->run(
+                $cacheConfig['backend_options']['server'],
+                $cacheConfig['backend_options']['port'],
+                $cacheConfig['backend_options']['database']
+            );
+
+            $this->logger->info('Keys evicted');
+        }
+
+        return $evictedKeys;
+    }
+
+    /**
+     * @param string $host
+     * @param int $port
+     * @param int $db
+     * @return int
+     */
+    private function run(string $host, int $port, int $db): int
+    {
+        $client = new Client($host, $port, null, '', $db);
+        $evictedKeys = 0;
+
+        do {
+            $keys = $client->scan($iterator, '*', self::EVICTION_LIMIT);
+
+            if ($keys === false) {
+                $this->logger->debug('Reached end');
+            } else {
+                $keysCount = count($keys);
+                $evictedKeys += $keysCount;
+
+                $this->logger->debug(sprintf('Evicted keys count: %s', $keysCount));
+            }
+        } while ($iterator > 0);
+
+        return $evictedKeys;
+    }
+}

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -18,6 +18,7 @@ use Credis_Client as Client;
 class Evictor
 {
     const EVICTION_LIMIT = 10000;
+    const CONFIG_PATH = 'cache_evict/enabled';
 
     /**
      * @var DeploymentConfig

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -47,10 +47,11 @@ class Evictor
      */
     public function evict(): int
     {
-        $cacheOptions = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE)[FrontendPool::KEY_FRONTEND_CACHE] ?? [];
+        $options = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE)[FrontendPool::KEY_FRONTEND_CACHE]
+            ?? [];
         $evictedKeys = 0;
 
-        foreach ($cacheOptions as $name => $cacheConfig) {
+        foreach ($options as $name => $cacheConfig) {
             $this->logger->info(sprintf(
                 'Evicting keys for "%s" database',
                 $name

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -57,6 +57,19 @@ class Evictor
                 $name
             ));
 
+            if (!isset(
+                $cacheConfig['backend_options']['server'],
+                $cacheConfig['backend_options']['port'],
+                $cacheConfig['backend_options']['database']
+            )) {
+                $this->logger->debug(sprintf(
+                    'Cache for database "%s" config is not valid',
+                    $name
+                ));
+
+                continue;
+            }
+
             $dbKeys = $this->run(
                 $cacheConfig['backend_options']['server'],
                 $cacheConfig['backend_options']['port'],

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -111,7 +111,7 @@ class Evictor
             }
 
             /* Give Redis some time to handle other requests */
-            usleep(20000);
+            usleep(100);
         } while ($iterator > 0);
 
         return $evictedKeys;

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -53,7 +53,7 @@ class Evictor
 
         foreach ($options as $name => $cacheConfig) {
             $this->logger->info(sprintf(
-                'Evicting keys for "%s" database',
+                'Scanning keys for "%s" database',
                 $name
             ));
 
@@ -77,7 +77,7 @@ class Evictor
             );
             $evictedKeys += $dbKeys;
 
-            $this->logger->info(sprintf('Keys evicted: %s', $dbKeys));
+            $this->logger->info(sprintf('Keys scanned: %s', $dbKeys));
         }
 
         return $evictedKeys;

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -109,6 +109,9 @@ class Evictor
                 $keysCount = count($keys);
                 $evictedKeys += $keysCount;
             }
+
+            /* Give Redis some time to handle other requests */
+            usleep(20000);
         } while ($iterator > 0);
 
         return $evictedKeys;

--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -19,7 +19,7 @@ use Cm_Cache_Backend_Redis as Backend;
 class Evictor
 {
     const DEFAULT_EVICTION_LIMIT = 10000;
-    const DEFAULT_SLEEP_TIMEOUT = 100;
+    const DEFAULT_SLEEP_TIMEOUT = 20000;
     const CONFIG_PATH_ENABLED = 'cache_evict/enabled';
     const CONFIG_PATH_LIMIT = 'cache_evict/limit';
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": "^7.0",
     "ext-json": "*",
+    "colinmollenhour/cache-backend-redis": "^1.9",
     "colinmollenhour/credis": "^1.6",
     "newrelic/monolog-enricher": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": "^7.0",
     "ext-json": "*",
+    "colinmollenhour/credis": "^1.6",
     "newrelic/monolog-enricher": "^1.0"
   },
   "suggest": {
@@ -20,6 +21,9 @@
     "phpstan/phpstan": "^0.11",
     "phpunit/phpunit": "^6.2",
     "squizlabs/php_codesniffer": "^3.0"
+  },
+  "config": {
+    "sort-packages": true
   },
   "scripts": {
     "test": [

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="cache_evict">
-        <job name="cache_evict_keys" instance="Magento\CloudComponents\Cron\Eviction" method="execute">
+        <job name="cache_evict_keys" instance="Magento\CloudComponents\Cron\Evict" method="execute">
             <schedule>0 */12 * * *</schedule>
         </job>
     </group>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="cache_evict">
+        <job name="cache_evict_keys" instance="Magento\CloudComponents\Cron\Eviction" method="execute">
+            <schedule>0 */12 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,6 +12,7 @@
                 <item name="configShowStoreUrlCommand" xsi:type="object">Magento\CloudComponents\Console\Command\ConfigShowStoreUrlCommand</item>
                 <item name="configShowEntityUrlsCommand" xsi:type="object">Magento\CloudComponents\Console\Command\ConfigShowEntityUrlsCommand</item>
                 <item name="ConfigShowDefaultUrlCommand" xsi:type="object">Magento\CloudComponents\Console\Command\ConfigShowDefaultUrlCommand</item>
+                <item name="CacheEvict" xsi:type="object">Magento\CloudComponents\Console\Command\CacheEvict</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Per Redis (https://docs.redislabs.com/latest/ri/memory-optimizations/reclaim-expired-keys-memory-faster)

You can set up a cron job that runs the scan command after an interval which helps in reclaiming the memory of the expired keys.

A cron job should be created that will use the SCAN command with a COUNT parameter (value 10,000) that will run every 12 hours. Details can be found in the following links:

* https://serverfault.com/questions/724047/avoiding-swap-on-elasticache-redis
* https://docs.redislabs.com/latest/ri/memory-optimizations/reclaim-expired-keys-memory-faster/
* https://tech.trivago.com/2017/01/25/learn-redis-the-hard-way-in-production/
* https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/improving-key-expiration-in-redis.html
* https://natmeurer.com/redis-setting-up-a-regularly-updated-cache-using-azure/

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-components#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-6023

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run `./bin/magento cache:evict` from CLI
1. Observe the non-zero number of evicted keys
1. Remove logs `rm -rf var/log/*`
1. Enable cron process by setting `'cache_evict' => ['enabled' => 1],` in `app/etc/env.php`
1. Run cron manually `bin/magento cron:run`
1. Run `cat var/log/system.log | grep "Keys scanned: "` and see log entries

### Release notes

Added command `./bin/magento cache:evict` to force run Redis Sync and evict expired keys

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
