### PR TITLE
MAGECLOUD-6422: NewRelic Log Enricher - Reported Performance Degradation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
   "version": "1.0.5",
   "require": {
     "php": "^7.0",
-    "ext-json": "*",
-    "newrelic/monolog-enricher": "^1.0"
+    "ext-json": "*"
   },
   "suggest": {
     "magento/framework": "*",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,18 +16,6 @@
         </arguments>
     </type>
 
-    <!-- Enable NewRelic Logs in Context -->
-    <type name="Magento\Framework\Logger\Monolog">
-        <arguments>
-            <argument name="handlers"  xsi:type="array">
-                <item name="newRelic" xsi:type="object">NewRelic\Monolog\Enricher\Handler</item>
-            </argument>
-            <argument name="processors"  xsi:type="array">
-                <item name="newRelic" xsi:type="object">NewRelic\Monolog\Enricher\Processor</item>
-            </argument>
-        </arguments>
-    </type>
-
     <!-- Log cache invalidation event to separate file -->
     <type name="Magento\CloudComponents\Model\Logger\Handler\Debug">
         <arguments>


### PR DESCRIPTION

### Description
The log handler for New Relic logs in context is adding API calls to the New Relic logger causing duplicate log entries and performance degradation.

### Fixed Issues (if relevant)
1. MCLOUD-6422


### Manual testing scenarios
1. Review New Relic traces to confirm no calls to "log-api.newrelic.com" appear

### Release notes
Removed New Relic Logs in Context support.

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
