### PR TITLE
MCLOUD-6779: PHP Fatal error when running the command 'php bin/magent…

### DIFF
--- a/Model/Cache/Evictor.php
+++ b/Model/Cache/Evictor.php
@@ -74,9 +74,9 @@ class Evictor
             }
 
             $dbKeys = $this->run(
-                $cacheConfig['backend_options']['server'],
-                $cacheConfig['backend_options']['port'],
-                $cacheConfig['backend_options']['database']
+                (string)$cacheConfig['backend_options']['server'],
+                (int)$cacheConfig['backend_options']['port'],
+                (int)$cacheConfig['backend_options']['database']
             );
             $evictedKeys += $dbKeys;
 


### PR DESCRIPTION
…o cache:evict'

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-components#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/MCLOUD-6779

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Find cache settings in `app.etc/env.php` and replace integer values to string for `port` and `database` (ie `80` => `'80'`)
2. Run `php bin/magento cache:evict`

### Release notes

Fixed a type error in the cache configuration values that caused the Magento CLI key eviction command (`php bin/magento cache:evict`) to fail.

### Associated documentation updates

Not required

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
